### PR TITLE
#167125363 Fix Cloudinary uploads on Heroku

### DIFF
--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -63,14 +63,15 @@ class UserAdmin(BaseUserAdmin):
     # The fields to be used in displaying the User model.
     # These override the definitions on the base UserAdmin
     # that reference specific fields on auth.User.
-    list_display = ('email', 'is_superuser', 'first_name', 'last_name')
+    list_display = ('email', 'is_superuser', 'first_name', 'last_name', 'role')
     list_filter = ('created_at', 'is_superuser',)
     fieldsets = (
         (None, {'fields': ('password',)}),
         ('Personal info', {
          'fields': ('email', 'first_name', 'last_name', 'username')}),
         ('Permissions', {
-         'fields': ('is_superuser', 'is_staff', 'groups', 'user_permissions')}),
+         'fields': (
+             'is_superuser', 'is_staff', 'groups', 'user_permissions')}),
         ('User Roles', {
             'fields': ('is_active', 'role', 'is_verified')
         }),
@@ -80,7 +81,8 @@ class UserAdmin(BaseUserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('email', 'first_name', 'last_name', 'password1', 'password2')}
+            'fields': (
+                'email', 'first_name', 'last_name', 'password1', 'password2')}
          ),
     )
     search_fields = ('email', 'first_name', 'last_name', 'username'),
@@ -106,7 +108,7 @@ class ClientAdmin(admin.ModelAdmin):
 
     def response_post_save_change(self, request, obj):
         """
-        Figure out where to redirect after the 'Save' button has been pressed 
+        Figure out where to redirect after the 'Save' button has been pressed
         when editing an existing object.
         """
         if obj.approval_status == 'approved':
@@ -118,7 +120,10 @@ class ClientAdmin(admin.ModelAdmin):
             EmailHelper.send_an_email(data=data, from_approval=True)
             return self._response_post_save(request, obj)
         else:
-            messages.info(request, message="Please add a reason for your action in the text box below")
+            messages.info(
+                request, message=("Please add a reason for your action "
+                                  "in the text box below")
+            )
             return HttpResponseRedirect("/api/v1/auth/admin/notes/?status={}&client={}".format(obj.approval_status, obj.client_admin.email))
 
 


### PR DESCRIPTION
## Description ##
When attempting to create property on Heroku, the server closes the connection immaturely. Current causes could be because of the uploads taking too long or not passing the request as authenticated users. However, this PR introduces logging first so we can get to the root of the problem.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#167125363](https://www.pivotaltracker.com/story/show/167125363)